### PR TITLE
Fix for error when deploying

### DIFF
--- a/deploy/aws-account-shredder-template.yaml
+++ b/deploy/aws-account-shredder-template.yaml
@@ -6,7 +6,7 @@ metadata:
 parameters:
   - name: IMAGE
     required: true
-    value: quay.io/agautam/aws-account-shredder
+    value: quay.io/app-sre/aws-account-shredder
   - name: IMAGE_TAG
     required: true
     value: latest
@@ -87,7 +87,7 @@ objects:
           containers:
             - name: aws-account-shredder
               image: ${IMAGE}:${IMAGE_TAG}
-              imagepullpolicy: always
+              imagepullpolicy: Always
               resources:
                 requests:
                   memory: "100Mi"

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -17,8 +17,8 @@ spec:
       serviceAccountName: aws-account-shredder
       containers:
         - name: aws-account-shredder
-          image: quay.io/agautam/aws-account-shredder:latest
-          imagePullPolicy: always
+          image: quay.io/app-sre/aws-account-shredder:latest
+          imagePullPolicy: Always
           resources:
             requestes:
               memory: "100Mi"


### PR DESCRIPTION
Ran into this error when deploying the project:

`The Deployment "aws-account-shredder" is invalid: spec.template.spec.containers[0].imagePullPolicy: Unsupported value: "always": supported values: "Always", "IfNotPresent", "Never"`

This PR simply updates the imagePullPolicy value from `always` to `Always`