### PR TITLE
Fixes typo in deployment

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: aws-account-shredder
   name: aws-account-shredder
   labels:
     name: aws-account-shredder
@@ -20,7 +21,7 @@ spec:
           image: quay.io/app-sre/aws-account-shredder:latest
           imagePullPolicy: Always
           resources:
-            requestes:
+            requests:
               memory: "100Mi"
             limits:
               memory: "2048Mi"


### PR DESCRIPTION
Fixes Requests typo in deployment so you can actually run this locally with minimal changes thanks to CRC's heavy resource usage.

Previous Configuration would try to request 2G of memory, now it only needs 100M of memory to deploy with ability to burst to 2G.