### PR TITLE
Disables EFS until it can be fixed.

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,8 +111,6 @@ func main() {
 				allErrors = append(allErrors, awsManager.CleanS3Instances(assumedRoleClient, logger))
 				allErrors = append(allErrors, awsManager.CleanEc2Instances(assumedRoleClient, logger))
 				allErrors = append(allErrors, awsManager.CleanUpAwsRoute53(assumedRoleClient, logger))
-				allErrors = append(allErrors, awsManager.CleanEFSMountTargets(assumedRoleClient, logger))
-				allErrors = append(allErrors, awsManager.CleanEFS(assumedRoleClient, logger))
 				allErrors = append(allErrors, awsManager.CleanVpcInstances(assumedRoleClient, logger))
 				allErrors = append(allErrors, awsManager.CleanEbsSnapshots(assumedRoleClient, logger))
 				allErrors = append(allErrors, awsManager.CleanEbsVolumes(assumedRoleClient, logger))


### PR DESCRIPTION
EFS DescribeMountTargets is throwing an API error and preventing accounts from becoming successfully reset and moved back to a 'Ready' state.  This PR disables the EFS cleanup until we can circle back to take care of that issue via [OSD-5616](https://issues.redhat.com/browse/OSD-5616).