### PR TITLE
Fix Dockerfile image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.13 AS builder
 
 RUN mkdir -p /workdir
 WORKDIR /workdir


### PR DESCRIPTION
registry.ci is the new image registry that replaces (old)registry.svc as per https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/. We can transition to use the new as the public images are supported and available by CI.