### PR TITLE
Bad log formating in multiple places

### DIFF
--- a/pkg/awsManager/ebsManager.go
+++ b/pkg/awsManager/ebsManager.go
@@ -54,7 +54,7 @@ func DeleteEbsSnapshots(client clientpkg.Client, ebsSnapshotsToBeDeleted []*stri
 
 		_, ebsSnapshotDeleteError := client.DeleteSnapshot(&ec2.DeleteSnapshotInput{SnapshotId: ebsSnapshotID})
 		if ebsSnapshotDeleteError != nil {
-			logger.Error(ebsSnapshotDeleteError, "Failed to delete snapshot", *ebsSnapshotID)
+			logger.Error(ebsSnapshotDeleteError, "Failed to delete snapshot", "ID", *ebsSnapshotID)
 			ebsSnapshotsNotDeleted = append(ebsSnapshotsNotDeleted, ebsSnapshotID)
 			localMetrics.ResourceFail(localMetrics.EbsSnapshot, client.GetRegion())
 			continue
@@ -107,7 +107,7 @@ func DeleteEbsVolumes(client clientpkg.Client, ebsVolumesToBeDeleted []*string, 
 
 		_, err := client.DeleteVolume(&ec2.DeleteVolumeInput{VolumeId: ebsVolumeID})
 		if err != nil {
-			logger.Error(err, "Failed to delete Volume", *ebsVolumeID)
+			logger.Error(err, "Failed to delete Volume", "ID", *ebsVolumeID)
 			ebsVolumesNotDeleted = append(ebsVolumesNotDeleted, ebsVolumeID)
 			localMetrics.ResourceFail(localMetrics.EbsVolume, client.GetRegion())
 			continue

--- a/pkg/awsManager/ec2Manager.go
+++ b/pkg/awsManager/ec2Manager.go
@@ -65,10 +65,10 @@ func DeleteEc2Instance(client clientpkg.Client, EC2InstancesToBeDeleted []*strin
 		if err, ok := err.(awserr.Error); ok {
 			switch err.Code() {
 			default:
-				logger.Error(err, "Failed to delete instances provided", &EC2InstancesToBeDeleted)
+				logger.Error(err, "Failed to delete instances provided", "Instances", &EC2InstancesToBeDeleted)
 			}
 		} else {
-			logger.Error(err, "Failed to delete instances provided", &EC2InstancesToBeDeleted)
+			logger.Error(err, "Failed to delete instances provided", "Instances", &EC2InstancesToBeDeleted)
 		}
 		localMetrics.ResourceFail(localMetrics.Ec2Instance, client.GetRegion())
 		return errors.New("FailedToDeleteEc2Instance")

--- a/pkg/awsManager/efsManager.go
+++ b/pkg/awsManager/efsManager.go
@@ -64,7 +64,7 @@ func DeleteEFSMountTarget(client clientpkg.Client, mountTargetToBeDeleted []*str
 	for _, mountTarget := range mountTargetToBeDeleted {
 		_, err := client.DeleteMountTarget(&efs.DeleteMountTargetInput{MountTargetId: mountTarget})
 		if err != nil {
-			logger.Error(err, "Unable to remove the mount-target", *mountTarget)
+			logger.Error(err, "Unable to remove the mount-target", "ID", *mountTarget)
 			mountTargetNotDeleted = append(mountTargetNotDeleted, mountTarget)
 			localMetrics.ResourceFail(localMetrics.EfsVolume, client.GetRegion())
 			continue
@@ -135,7 +135,7 @@ func DeleteEFS(client clientpkg.Client, fileSystemToBeDeleted []*string, logger 
 	for _, fileSystem := range fileSystemToBeDeleted {
 		_, err := client.DeleteFileSystem(&efs.DeleteFileSystemInput{FileSystemId: fileSystem})
 		if err != nil {
-			logger.Info("Unable to remove file system", *fileSystem)
+			logger.Info("Unable to remove file system", "fileSystem", *fileSystem)
 			fileSystemNotDeleted = append(fileSystemNotDeleted, fileSystem)
 		}
 	}

--- a/pkg/awsManager/route53_manager.go
+++ b/pkg/awsManager/route53_manager.go
@@ -35,7 +35,7 @@ func CleanUpAwsRoute53(client clientpkg.Client, logger logr.Logger) error {
 			for {
 				recordSet, listRecordsError := client.ListResourceRecordSets(&route53.ListResourceRecordSetsInput{HostedZoneId: zone.Id, StartRecordName: nextRecordName})
 				if listRecordsError != nil {
-					logger.Error(listRecordsError, "Failed to list Record sets for hosted zone", *zone.Name)
+					logger.Error(listRecordsError, "Failed to list Record sets for hosted zone", "Name", *zone.Name)
 					errFlag = true
 				}
 
@@ -55,7 +55,7 @@ func CleanUpAwsRoute53(client clientpkg.Client, logger logr.Logger) error {
 				if changeBatch.Changes != nil {
 					_, changeErr := client.ChangeResourceRecordSets(&route53.ChangeResourceRecordSetsInput{HostedZoneId: zone.Id, ChangeBatch: changeBatch})
 					if changeErr != nil {
-						logger.Error(changeErr, "Failed to delete record sets for hosted zone", *zone.Name)
+						logger.Error(changeErr, "Failed to delete record sets for hosted zone", "Name", *zone.Name)
 						errFlag = true
 						localMetrics.ResourceFail(localMetrics.Route53RecordSet, client.GetRegion())
 					} else {
@@ -73,7 +73,7 @@ func CleanUpAwsRoute53(client clientpkg.Client, logger logr.Logger) error {
 
 			_, deleteError := client.DeleteHostedZone(&route53.DeleteHostedZoneInput{Id: zone.Id})
 			if deleteError != nil {
-				logger.Error(err, "failed to delete HostedZone", zone.Id)
+				logger.Error(err, "failed to delete HostedZone", "ID", zone.Id)
 				errFlag = true
 				localMetrics.ResourceFail(localMetrics.Route53HostedZone, client.GetRegion())
 				continue

--- a/pkg/awsManager/vpcVpnManager.go
+++ b/pkg/awsManager/vpcVpnManager.go
@@ -168,7 +168,7 @@ func DeleteELB(client clientpkg.Client, vpcID *string, logger logr.Logger) error
 			if *elasticLoadBalancer.VPCId == *vpcID {
 				_, err := client.DeleteLoadBalancer(&elb.DeleteLoadBalancerInput{LoadBalancerName: elasticLoadBalancer.LoadBalancerName})
 				if err != nil {
-					logger.Error(err, "Failed to delete ELB", *elasticLoadBalancer.LoadBalancerName)
+					logger.Error(err, "Failed to delete ELB", "Name", *elasticLoadBalancer.LoadBalancerName)
 					localMetrics.ResourceFail(localMetrics.ElasticLoadBalancer, client.GetRegion())
 					continue
 				}
@@ -199,7 +199,7 @@ func DeleteNatgateway(client clientpkg.Client, vpcID *string, logger logr.Logger
 			if *natGateway.VpcId == *vpcID {
 				_, err := client.DeleteNatGateway(&ec2.DeleteNatGatewayInput{NatGatewayId: natGateway.NatGatewayId})
 				if err != nil {
-					logger.Error(err, "Failed to delete NAT Gateway", *natGateway.NatGatewayId)
+					logger.Error(err, "Failed to delete NAT Gateway", "ID", *natGateway.NatGatewayId)
 					localMetrics.ResourceFail(localMetrics.NatGateway, client.GetRegion())
 					continue
 				}
@@ -229,7 +229,7 @@ func DeleteNetworkLoadBalancer(client clientpkg.Client, vpcID *string, logger lo
 			if *networkLoadBalancer.VpcId == *vpcID {
 				_, err := client.DeleteLoadBalancer2(&elbv2.DeleteLoadBalancerInput{LoadBalancerArn: networkLoadBalancer.LoadBalancerArn})
 				if err != nil {
-					logger.Error(err, "Failed to delete Network Load Balancer", *networkLoadBalancer.LoadBalancerName)
+					logger.Error(err, "Failed to delete Network Load Balancer", "Name", *networkLoadBalancer.LoadBalancerName)
 					localMetrics.ResourceFail(localMetrics.NetworkLoadBalancer, client.GetRegion())
 					continue
 				}
@@ -262,13 +262,13 @@ func DetachAndDeleteNetworkInterface(client clientpkg.Client, vpcID *string, log
 			if *networkInterface.VpcId == *vpcID {
 				_, err := client.DetachNetworkInterface(&ec2.DetachNetworkInterfaceInput{AttachmentId: networkInterface.NetworkInterfaceId})
 				if err != nil {
-					logger.Error(err, "Failure to detach interface", *networkInterface.NetworkInterfaceId)
+					logger.Error(err, "Failure to detach interface", "ID", *networkInterface.NetworkInterfaceId)
 				}
 
 				// delete interface
 				_, err = client.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{NetworkInterfaceId: networkInterface.NetworkInterfaceId})
 				if err != nil {
-					logger.Error(err, "Failed to delete Network Interface", *networkInterface.NetworkInterfaceId)
+					logger.Error(err, "Failed to delete Network Interface", "ID", *networkInterface.NetworkInterfaceId)
 					localMetrics.ResourceFail(localMetrics.NetworkInterface, client.GetRegion())
 					continue
 				}
@@ -299,12 +299,12 @@ func DeleteGateway(client clientpkg.Client, vpcID *string, logger logr.Logger) e
 				if *attachments.VpcId == *vpcID {
 					_, err := client.DetachInternetGateway(&ec2.DetachInternetGatewayInput{InternetGatewayId: gateway.InternetGatewayId, VpcId: attachments.VpcId})
 					if err != nil {
-						logger.Error(err, "Failed to detach Internet Gateway", *gateway.InternetGatewayId)
+						logger.Error(err, "Failed to detach Internet Gateway", "ID", *gateway.InternetGatewayId)
 					}
 					// delete internet gateway
 					_, err = client.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{InternetGatewayId: gateway.InternetGatewayId})
 					if err != nil {
-						logger.Error(err, "Failed to delete Internet Gateway", *gateway.InternetGatewayId)
+						logger.Error(err, "Failed to delete Internet Gateway", "ID", *gateway.InternetGatewayId)
 						localMetrics.ResourceFail(localMetrics.InternetGateway, client.GetRegion())
 						continue
 					}
@@ -336,7 +336,7 @@ func DeleteSubnetsForVPC(client clientpkg.Client, vpcId *string, logger logr.Log
 			if *subnet.VpcId == *vpcId {
 				_, err := client.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: subnet.SubnetId})
 				if err != nil {
-					logger.Error(err, "Failed to delete subnet-id", *subnet.SubnetId)
+					logger.Error(err, "Failed to delete subnet-id", "ID", *subnet.SubnetId)
 					localMetrics.ResourceFail(localMetrics.Subnet, client.GetRegion())
 					continue
 				}
@@ -369,7 +369,7 @@ func DeleteRouteTables(client clientpkg.Client, vpcId *string, logger logr.Logge
 					//disassociate route table
 					_, err = client.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{AssociationId: association.RouteTableAssociationId})
 					if err != nil {
-						logger.Error(err, "Failed to disassociate route-table", *routeTable.RouteTableId)
+						logger.Error(err, "Failed to disassociate route-table", "ID", *routeTable.RouteTableId)
 					}
 				}
 			}
@@ -380,7 +380,7 @@ func DeleteRouteTables(client clientpkg.Client, vpcId *string, logger logr.Logge
 
 				_, err = client.DeleteRouteTable(&ec2.DeleteRouteTableInput{RouteTableId: routeTable.RouteTableId})
 				if err != nil {
-					logger.Error(err, "Failed to delete route-table", *routeTable.RouteTableId)
+					logger.Error(err, "Failed to delete route-table", "ID", *routeTable.RouteTableId)
 					localMetrics.ResourceFail(localMetrics.RouteTable, client.GetRegion())
 					continue
 				}
@@ -413,7 +413,7 @@ func DeleteNetworkAcl(client clientpkg.Client, vpcId *string, logger logr.Logger
 			if *acl.VpcId == *vpcId {
 				_, err := client.DeleteNetworkAcl(&ec2.DeleteNetworkAclInput{NetworkAclId: acl.NetworkAclId})
 				if err != nil {
-					logger.Error(err, "Failed to delete ACL", *acl.NetworkAclId)
+					logger.Error(err, "Failed to delete ACL", "ID", *acl.NetworkAclId)
 					localMetrics.ResourceFail(localMetrics.NetworkACL, client.GetRegion())
 					continue
 				}
@@ -456,7 +456,7 @@ func DeleteSecurityGroups(client clientpkg.Client, vpcId *string, logger logr.Lo
 			if *securityGroup.VpcId == *vpcId {
 				_, err = client.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{GroupId: securityGroup.GroupId})
 				if err != nil {
-					logger.Error(err, "Failed to delete Security Group", *securityGroup.GroupId)
+					logger.Error(err, "Failed to delete Security Group", "ID", *securityGroup.GroupId)
 					localMetrics.ResourceFail(localMetrics.SecurityGroup, client.GetRegion())
 					continue
 				}
@@ -503,7 +503,7 @@ func DeleteVpcEndpoint(client clientpkg.Client, vpcId *string, logger logr.Logge
 
 	vpcNotDeleted, err := client.DeleteVpcEndpoints(&ec2.DeleteVpcEndpointsInput{VpcEndpointIds: vpcEndpointToBeDeleted})
 	if err != nil {
-		logger.Error(err, "Failed to delete VPC", vpcNotDeleted.String())
+		logger.Error(err, "Failed to delete VPC", "Name", vpcNotDeleted.String())
 		localMetrics.ResourceFail(localMetrics.VPC, client.GetRegion())
 	} else {
 		logger.Info("ALL VPCs have been deleted successfully")
@@ -524,7 +524,7 @@ func DeleteVpnConnections(client clientpkg.Client, logger logr.Logger) error {
 	for _, vpnConnection := range vpnConnectionList.VpnConnections {
 		_, err = client.DeleteVpnConnection(&ec2.DeleteVpnConnectionInput{VpnConnectionId: vpnConnection.VpnConnectionId})
 		if err != nil {
-			logger.Error(err, "Failed to delete VPN connection", *vpnConnection.VpnConnectionId)
+			logger.Error(err, "Failed to delete VPN connection", "vpnID", *vpnConnection.VpnConnectionId)
 			localMetrics.ResourceFail(localMetrics.VpnConnection, client.GetRegion())
 			continue
 		}
@@ -547,7 +547,7 @@ func DetachVpnGateway(client clientpkg.Client, vpcId *string, logger logr.Logger
 	for _, vpnGateway := range vpnGatewayList.VpnGateways {
 		_, err = client.DetachVpnGateway(&ec2.DetachVpnGatewayInput{VpcId: vpcId, VpnGatewayId: vpnGateway.VpnGatewayId})
 		if err != nil {
-			logger.Error(err, "Failed to detach VPN gateway", *vpnGateway.VpnGatewayId)
+			logger.Error(err, "Failed to detach VPN gateway", "ID", *vpnGateway.VpnGatewayId)
 			localMetrics.ResourceFail(localMetrics.VpnGateway, client.GetRegion())
 			continue
 		}


### PR DESCRIPTION
Logs are filled with errors like these:

```
{"level":"dpanic","ts":1623433912.0868485,"logger":"shredder_logger","msg":"odd number of arguments passed as key-value pairs for logging","AccountName":"account-to-shred-088114532865","AccountID":"088114532865","Region":"us-east-1","ignored key":"managed-velero-backups-f0b828fb-edae-431b-aedf-5d12c97cbf1e","stacktrace":"github.com/go-logr/zapr.handleFields\n\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:106\ngithub.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:129\ngithub.com/openshift/aws-account-shredder/pkg/awsManager.DeleteS3Buckets\n\t/workdir/pkg/awsManager/s3Manager.go:46\ngithub.com/openshift/aws-account-shredder/pkg/awsManager.CleanS3Instances\n\t/workdir/pkg/awsManager/s3Manager.go:64\nmain.main\n\t/workdir/main.go:109\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203"}
```