### PR TITLE
[OSD-7582] Update account-reader role to allow AAO account update

### DIFF
--- a/deploy/aws-account-operator-template.yaml
+++ b/deploy/aws-account-operator-template.yaml
@@ -20,8 +20,7 @@ objects:
         resources:
           - accounts
         verbs:
-          - 'get'
-          - 'list'
+          - '*'
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:


### PR DESCRIPTION
Ref [OSD-7582](https://issues.redhat.com/browse/OSD-7582):
Updating deployment template to allow aws-account-shredder to update AAO account statuses to 'READY'. 