### PR TITLE
Reset account status instead of just the state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,8 +35,6 @@ require (
 	github.com/openshift/operator-custom-metrics v0.3.0
 	github.com/operator-framework/operator-sdk v0.12.0
 	github.com/prometheus/client_golang v1.7.1
-	github.com/spf13/pflag v1.0.5 // indirect
-	go.uber.org/zap v1.10.0 // indirect
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v12.0.0+incompatible

--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func main() {
 				}
 			}
 			if resetAccount {
-				awsv1alpha1.SetAccountStateReady(cli, account)
+				awsv1alpha1.ResetAccountStatus(cli, account)
 				localMetrics.Metrics.AccountSuccess.Inc()
 			} else {
 				localMetrics.Metrics.AccountFail.Inc()

--- a/pkg/awsv1alpha1/accounts.go
+++ b/pkg/awsv1alpha1/accounts.go
@@ -31,11 +31,11 @@ func GetAccountCRsToReset(ctx context.Context, cli client.Client) ([]awsv1alpha1
 }
 
 // SetAccountStateReady sets an account state to Ready
-func SetAccountStateReady(cli client.Client, account awsv1alpha1.Account) error {
-	account.Status.State = "Ready"
+func ResetAccountStatus(cli client.Client, account awsv1alpha1.Account) error {
+	account.Status = awsv1alpha1.AccountStatus{}
 	err := cli.Status().Update(context.TODO(), &account)
 	if err != nil {
-		fmt.Println("Failed to reset account to a \"Ready\" state: ", err)
+		fmt.Println("Failed to reset account status: ", err)
 	}
 	return err
 }


### PR DESCRIPTION
An account only goes through the shredder if the status.state becomes Failed. There are many reasons an account can become failed, including issues with the initialization of the IAM users, regions via the ec2 instance, etc. Resetting a shredded account directly to a 'Ready' state may cause issues if the account failed during initialization, and a reinit will be skipped with a Ready state. Instead, the account should be reset to a blank state so that it can be reconciled and reinitialized by the aws-account-operator. 