### PR TITLE
[OSD-7582] Adding accounts/staus to Role

### DIFF
--- a/deploy/aws-account-operator-template.yaml
+++ b/deploy/aws-account-operator-template.yaml
@@ -19,6 +19,7 @@ objects:
           - aws.managed.openshift.io
         resources:
           - accounts
+          - accounts/staus
         verbs:
           - '*'
   - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Ref [OSD-7582](https://issues.redhat.com/browse/OSD-7582):
Updating deployment template to allow aws-account-shredder to update AAO account statuses to 'READY'.