### PR TITLE
[OSD-7582] Fix Typo in template

### DIFF
--- a/deploy/aws-account-operator-template.yaml
+++ b/deploy/aws-account-operator-template.yaml
@@ -19,7 +19,7 @@ objects:
           - aws.managed.openshift.io
         resources:
           - accounts
-          - accounts/staus
+          - accounts/status
         verbs:
           - '*'
   - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Ref [OSD-7582](https://issues.redhat.com/browse/OSD-7582):
Updating deployment template to allow aws-account-shredder to update AAO account statuses to 'READY'.

Typo caused deployment errors: https://coreos.slack.com/archives/C0140EM7BFW/p1631624920061700