### PR TITLE
[OSD-7582] Reducing verb scope for account-reader role

### DIFF
--- a/deploy/aws-account-operator-template.yaml
+++ b/deploy/aws-account-operator-template.yaml
@@ -19,6 +19,7 @@ objects:
           - aws.managed.openshift.io
         resources:
           - accounts
+          - accounts/status
         verbs:
           - 'get'
           - 'list'

--- a/deploy/aws-account-operator-template.yaml
+++ b/deploy/aws-account-operator-template.yaml
@@ -20,7 +20,9 @@ objects:
         resources:
           - accounts
         verbs:
-          - '*'
+          - 'get'
+          - 'list'
+          - 'update'
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:


### PR DESCRIPTION
Ticket Ref: https://issues.redhat.com/browse/OSD-7582
Ref: https://coreos.slack.com/archives/C0140EM7BFW/p1631624920061700

```
Resource: "rbac.authorization.k8s.io/v1, Resource=roles", GroupVersionKind: "rbac.authorization.k8s.io/v1, Kind=Role"
Name: "account-reader", Namespace: "aws-account-operator"
for: "STDIN": roles.rbac.authorization.k8s.io "account-reader" is forbidden: user "system:serviceaccount:dedicated-admin:app-sre-bot" (groups=["system:serviceaccounts" "system:serviceaccounts:dedicated-admin" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["aws.managed.openshift.io"], Resources:["accounts/status"], Verbs:["*"]}
 (error details: https://github.com/openshift/aws-account-shredder/blob/master/deploy/aws-account-operator-template.yaml)
```

Reducing the scope of the verbs allowing by the role