### PR TITLE
[OSD-8355] Update Shredder to skip account CRs without AWS Account IDs

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"time"
 
@@ -80,8 +81,15 @@ func main() {
 
 		for _, account := range accountCRList {
 			startTime := time.Now()
+
 			logger := log.WithValues("AccountName", account.Name, "AccountID", account.Spec.AwsAccountID)
 			logger.Info("New Account being shredded") // Usefull for keeping track of when work begins on an account
+
+			if account.Spec.AwsAccountID == "" {
+				logger.Error(err, fmt.Sprintf("Account %s has no AWS Account ID attached", account.Name))
+				localMetrics.Metrics.AccountFail.Inc()
+				continue
+			}
 
 			// assuming roles for the given AccountID
 			RoleArnParameter := "arn:aws:iam::" + account.Spec.AwsAccountID + ":role/OrganizationAccountAccessRole"


### PR DESCRIPTION
Tested locally with a deployed Account CR without an AWS Account ID.
```
{"level":"info","ts":1632851205.0714147,"logger":"shredder_logger","msg":"New Account being shredded","AccountName":"aws-shredder-account-delete","AccountID":""}
{"level":"error","ts":1632851205.0715451,"logger":"shredder_logger","msg":"Account aws-shredder-account-delete has no AWS Account ID attached","AccountName":"aws-shredder-account-delete","AccountID":"","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\tpkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nmain.main\n\t/workdir/main.go:89\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:203"}
```

Open to changing this to an info log over error log 