### PR TITLE
[OSD-9749] Add batching to instance deletion

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,13 +97,13 @@ func main() {
 			RoleArnParameter := "arn:aws:iam::" + account.Spec.AwsAccountID + ":role/OrganizationAccountAccessRole"
 			assumedRole, err := awsClient.AssumeRole(&sts.AssumeRoleInput{RoleArn: aws.String(RoleArnParameter), RoleSessionName: aws.String(sessionName)})
 			if err != nil {
-				logger.Error(err, "Failed to assume necessary account role", RoleArnParameter)
+				logger.Error(err, "Failed to assume necessary account role", "RoleARN", RoleArnParameter)
 				localMetrics.Metrics.AccountFail.Inc()
 				// need continue , or else the next line will throw an error ( non existing pointer being deferenced)
 				// hence moving on to next element
 				continue
-
 			}
+
 			assumedAccessKey := *assumedRole.Credentials.AccessKeyId
 			assumedSecretKey := *assumedRole.Credentials.SecretAccessKey
 			assumedSessionToken := *assumedRole.Credentials.SessionToken

--- a/pkg/awsManager/aws_manager_test.go
+++ b/pkg/awsManager/aws_manager_test.go
@@ -2,6 +2,7 @@ package awsManager
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -89,6 +90,14 @@ func TestDeleteS3Buckets(t *testing.T) {
 	}
 }
 
+func createInstanceList(numInstances int) []*string {
+	var instanceList []*string
+	for i := 0; i < numInstances; i++ {
+		instanceList = append(instanceList, aws.String("i-0"+strconv.Itoa(i)))
+	}
+	return instanceList
+}
+
 func TestDeleteEc2Instance(t *testing.T) {
 
 	testCases := []struct {
@@ -119,6 +128,14 @@ func TestDeleteEc2Instance(t *testing.T) {
 				r.GetRegion().Return("Region1").AnyTimes()
 			},
 			listOfInstances: []*string{aws.String("abcd"), aws.String("abcd")},
+			errorExpected:   false,
+		}, {
+			title: "test 4 - many Instances passed",
+			setupAWSMock: func(r *mock.MockClientMockRecorder) {
+				r.TerminateInstances(gomock.Any()).Return(&ec2.TerminateInstancesOutput{}, nil).AnyTimes()
+				r.GetRegion().Return("Region1").AnyTimes()
+			},
+			listOfInstances: createInstanceList(123),
 			errorExpected:   false,
 		},
 	}

--- a/pkg/awsManager/ec2Manager.go
+++ b/pkg/awsManager/ec2Manager.go
@@ -62,7 +62,8 @@ func DeleteEc2Instance(client clientpkg.Client, EC2InstancesToBeDeleted []*strin
 		return nil
 	}
 
-	// We're batching the deletes to avoid hitting the limit of instances per request
+	// We're batching the deletes to avoid hitting the limit of instances per request.
+	// This uses a sliding window to iterate through the list in batches.
 	totalToDelete := len(EC2InstancesToBeDeleted)
 	for lowerBound, upperBound := 0, 0; lowerBound <= totalToDelete-1; lowerBound = upperBound {
 		upperBound = lowerBound + maxBatchSize


### PR DESCRIPTION
Add batching to instance deletion to avoid hitting the limit of instances per request
Jira: [OSD-9749](https://issues.redhat.com/browse/OSD-9749)