### PR TITLE
[OSD-11439] Add gosec to aws-account-shredder

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   disable-all: true
   enable:
+    - gosec
     - misspell
     - deadcode
     - errcheck

--- a/pkg/k8sWrapper/getSecrets.go
+++ b/pkg/k8sWrapper/getSecrets.go
@@ -10,10 +10,12 @@ import (
 )
 
 const (
-	awsCredsSecretIDKey     = "aws_access_key_id"
+	awsCredsSecretIDKey = "aws_access_key_id"
+	// #nosec - G101 no hardcoded credentials
 	awsCredsSecretAccessKey = "aws_secret_access_key"
-	namespace               = "aws-account-shredder"             // change the namespace according to your environment. this is the namespace, from where secret has to retreived from
-	secretName              = "aws-account-shredder-credentials" // the name of the secret to be read
+	namespace               = "aws-account-shredder" // change the namespace according to your environment. this is the namespace, from where secret has to retreived from
+	// #nosec - G101 no hardcoded credentials
+	secretName = "aws-account-shredder-credentials" // the name of the secret to be read
 )
 
 // read the credentials stored in aws-account-shredder to start up the connection to AWS


### PR DESCRIPTION
Adds `gosec` linter to the default linter configuration.

It only found to false-positives about hard-coded credentials, which I ignored using the gosec-comments.